### PR TITLE
Kyber mooniswap bridge reserve

### DIFF
--- a/contracts/KyberMooniswapReserve.sol
+++ b/contracts/KyberMooniswapReserve.sol
@@ -81,7 +81,7 @@ contract KyberMooniswapReserve is IKyberReserve, MooniswapSourceView, MooniswapS
 
         uint256 returnAmount = dst.uniBalanceOf(address(this));
         uint256 actualRate = _calcRateFromQty(srcAmount, returnAmount, src.uniDecimals(), dst.uniDecimals());
-        require(actualRate >= conversionRate, "Rate exceeded conversionRate");
+        require(actualRate >= conversionRate, "actualRate below network rate");
 
         dst.uniTransfer(destAddress, returnAmount);
         return true;

--- a/contracts/KyberMooniswapReserve.sol
+++ b/contracts/KyberMooniswapReserve.sol
@@ -30,7 +30,11 @@ interface IKyberReserve {
 contract KyberMooniswapReserve is IKyberReserve, MooniswapSourceView, MooniswapSourceSwap {
     using UniERC20 for IERC20;
 
-    address public constant KYBER_NETWORK = 0x7C66550C9c730B6fdd4C03bc2e73c5462c5F7ACC;
+    address public immutable kyberNetwork;
+
+    constructor(address _kyberNetwork) public {
+        kyberNetwork = _kyberNetwork;
+    }
 
     function getConversionRate(
         IERC20 src,
@@ -61,7 +65,7 @@ contract KyberMooniswapReserve is IKyberReserve, MooniswapSourceView, MooniswapS
         uint256 conversionRate,
         bool validate
     ) external payable override returns(bool) {
-        require(msg.sender == KYBER_NETWORK, "Access denied");
+        require(msg.sender == kyberNetwork, "Access denied");
 
         src.uniTransferFromSender(payable(address(this)), srcAmount);
         if (validate) {
@@ -77,11 +81,13 @@ contract KyberMooniswapReserve is IKyberReserve, MooniswapSourceView, MooniswapS
 
         uint256 returnAmount = dst.uniBalanceOf(address(this));
         uint256 actualRate = _calcRateFromQty(srcAmount, returnAmount, src.uniDecimals(), dst.uniDecimals());
-        require(actualRate <= conversionRate, "Rate exceeded conversionRate");
+        require(actualRate >= conversionRate, "Rate exceeded conversionRate");
 
         dst.uniTransfer(destAddress, returnAmount);
         return true;
     }
+
+    receive() external payable {}
 
     function _calcRateFromQty(
         uint256 srcAmount,

--- a/test/KyberMooniswapReserve.js
+++ b/test/KyberMooniswapReserve.js
@@ -1,0 +1,76 @@
+const { BN } = require('@openzeppelin/test-helpers/src/setup');
+const { expect } = require('chai');
+
+const IERC20 = artifacts.require('IERC20');
+const KyberMooniswapReserve = artifacts.require('KyberMooniswapReserve.sol');
+
+const ethAddress = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
+const ethDecimals = new BN(18);
+const usdtDecimals = new BN(6);
+
+let usdtToken;
+let reserve;
+
+contract('KyberMooniswapReserve', function (accounts) {
+    // set kybetNetwork as accounts[0] for permission to trade
+    const kyberNetwork = accounts[0];
+    before('set up', async () => {
+        usdtToken = await IERC20.at('0xdac17f958d2ee523a2206206994597c13d831ec7');
+        reserve = await KyberMooniswapReserve.new(kyberNetwork);
+    });
+
+    it('test swap eth to usdt', async () => {
+        const ethWei = new BN(10).pow(new BN(18));
+        const rate = await reserve.getConversionRate(
+            ethAddress,
+            usdtToken.address,
+            ethWei,
+            new BN(0),
+        );
+        const expectedDstQty = calcDstQty(ethWei, ethDecimals, usdtDecimals, rate);
+        const oldBalance = await usdtToken.balanceOf(kyberNetwork);
+        await reserve.trade(ethAddress, ethWei, usdtToken.address, kyberNetwork, rate, true, {
+            value: ethWei,
+        });
+        const newBalance = await usdtToken.balanceOf(kyberNetwork);
+        expect(expectedDstQty).to.be.bignumber.most(newBalance.sub(oldBalance));
+    });
+
+    it('test swap usdt to eth', async () => {
+        const tokenTwei = await usdtToken.balanceOf(kyberNetwork);
+        const rate = await reserve.getConversionRate(
+            usdtToken.address,
+            ethAddress,
+            tokenTwei,
+            new BN(0),
+        );
+        // approve from network to reserve
+        await usdtToken.approve(reserve.address, tokenTwei, { from: kyberNetwork });
+        const expectedDstQty = calcDstQty(tokenTwei, usdtDecimals, ethDecimals, rate);
+        const oldBalance = web3.utils.toBN(await web3.eth.getBalance(kyberNetwork));
+        await reserve.trade(usdtToken.address, tokenTwei, ethAddress, kyberNetwork, rate, true, {
+            gasPrice: new BN(0),
+        });
+        // check new balance as expected
+        const newBalance = await web3.utils.toBN(await web3.eth.getBalance(kyberNetwork));
+        expect(expectedDstQty).to.be.bignumber.most(newBalance.sub(oldBalance));
+    });
+});
+
+function calcDstQty (srcQty, srcDecimals, dstDecimals, rate) {
+    srcQty = new BN(srcQty);
+    srcDecimals = new BN(srcDecimals);
+    dstDecimals = new BN(dstDecimals);
+    rate = new BN(rate);
+    const precisionUnits = new BN(10).pow(new BN(18));
+    if (dstDecimals.gte(srcDecimals)) {
+        return srcQty
+            .mul(rate)
+            .mul(new BN(10).pow(new BN(dstDecimals.sub(srcDecimals))))
+            .div(precisionUnits);
+    } else {
+        return srcQty
+            .mul(rate)
+            .div(precisionUnits.mul(new BN(10).pow(new BN(srcDecimals.sub(dstDecimals)))));
+    }
+}


### PR DESCRIPTION
What does this PR do:
- add network address to constructor so it is easier to test, deploy on different environments (staging, production)
- actual rate must greater nor equal conversion rate 
- add an receive method, so when trade token to ether, this contract can receive ether

Also add an unit test